### PR TITLE
fix: pin alpine version

### DIFF
--- a/ci/docker/base-tester.Dockerfile
+++ b/ci/docker/base-tester.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.18
 ARG PIP_PACKAGES
 
 ENV PYTHONUNBUFFERED=1

--- a/ci/docker/duckdb.Dockerfile
+++ b/ci/docker/duckdb.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.18
 
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python

--- a/ci/docker/sqlite.Dockerfile
+++ b/ci/docker/sqlite.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.18
 
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python


### PR DESCRIPTION
Pinning alpine to 3.18 since the latest alpine is causing the CI to fail during
the docker compose