### PR TITLE
fix: uri resolution for generated pages

### DIFF
--- a/bft/core/function.py
+++ b/bft/core/function.py
@@ -15,9 +15,15 @@ class Kernel(NamedTuple):
 
 class FunctionDefinition(object):
     def __init__(
-        self, name: str, description: str, options: List[Option], kernels: List[Kernel]
+        self,
+        name: str,
+        uri: str,
+        description: str,
+        options: List[Option],
+        kernels: List[Kernel],
     ):
         self.name = name
+        self.uri = uri
         self.description = description
         self.options = options
         self.kernels = kernels
@@ -34,12 +40,16 @@ class FunctionDefinition(object):
 class FunctionBuilder(object):
     def __init__(self, name: str):
         self.name = name
+        self.uri: str = None
         self.description: str = None
         self.options = {}
         self.kernels = []
 
     def set_description(self, description: str):
         self.description = description
+
+    def set_uri(self, uri: str):
+        self.uri = uri
 
     def try_set_description(self, description: str):
         if self.description is None:
@@ -70,7 +80,9 @@ class FunctionBuilder(object):
         opts = []
         for key, values in self.options.items():
             opts.append(Option(key, values))
-        return FunctionDefinition(self.name, self.description, opts, self.kernels)
+        return FunctionDefinition(
+            self.name, self.uri, self.description, opts, self.kernels
+        )
 
 
 class LibraryBuilder(object):

--- a/bft/html/builder.py
+++ b/bft/html/builder.py
@@ -9,16 +9,19 @@ from bft.core.function import FunctionDefinition, Kernel, Option
 from bft.core.index_parser import IndexFunctionsFile, load_index
 from bft.dialects.loader import load_dialects
 from bft.dialects.types import Dialect, DialectsLibrary
-from bft.html.types import (
-    FunctionIndexInfo, FunctionIndexItem, ScalarFunctionDetailInfo,
-    ScalarFunctionDialectInfo, ScalarFunctionExampleCaseInfo,
-    ScalarFunctionExampleGroupInfo, ScalarFunctionInfo, ScalarFunctionOptionInfo,
-    ScalarFunctionOptionValueInfo, ScalarFunctionPropertyInfo)
+from bft.html.types import (FunctionIndexInfo, FunctionIndexItem,
+                            ScalarFunctionDetailInfo,
+                            ScalarFunctionDialectInfo,
+                            ScalarFunctionExampleCaseInfo,
+                            ScalarFunctionExampleGroupInfo, ScalarFunctionInfo,
+                            ScalarFunctionOptionInfo,
+                            ScalarFunctionOptionValueInfo,
+                            ScalarFunctionPropertyInfo)
 from bft.substrait.extension_file_parser import (
     ExtensionFileParser, LibraryBuilder, add_extensions_file_to_library)
 from bft.supplements.parser import load_supplements
-from bft.supplements.types import (
-    BasicSupplement, OptionSupplement, SupplementsFile, empty_supplements_file)
+from bft.supplements.types import (BasicSupplement, OptionSupplement,
+                                   SupplementsFile, empty_supplements_file)
 
 env = Environment(loader=PackageLoader("bft"), autoescape=select_autoescape())
 
@@ -138,11 +141,10 @@ def create_function_info(
     cases: List[Case],
     supplements: SupplementsFile,
     dialects: DialectsLibrary,
-    function_file: IndexFunctionsFile,
 ) -> ScalarFunctionInfo:
     name = func.name
-    uri = "https://TODO"
-    uri_short = pathlib.Path(function_file[0]).name
+    uri_short = func.uri
+    uri = "https://github.com/substrait-io/substrait/blob/main/extensions/" + uri_short
     brief = func.description
     options = [create_function_option(opt, supplements) for opt in func.options]
     kernels = func.kernels
@@ -175,7 +177,6 @@ def create_function_index(
         FunctionIndexItem(
             function.name,
             function.description,
-            True,  # TODO: only avoid generating Function index if no information at all is present
         )
         for function in functions
     ]
@@ -186,12 +187,11 @@ def build_site(index_path: str, dest_dir):
     root = pathlib.Path(index_path).parent
     index_contents = load_index(index_path)
     library_builder = LibraryBuilder()
-    print(index_contents)
     for function_file in index_contents.function_files:
         resolved_location = (root / function_file.location).resolve()
         with open(resolved_location, "rb") as f:
             add_extensions_file_to_library(
-                ExtensionFileParser().parse(f), library_builder
+                resolved_location, ExtensionFileParser().parse(f), library_builder
             )
     functions = library_builder.finish()
 
@@ -216,16 +216,13 @@ def build_site(index_path: str, dest_dir):
     print(
         f"There are {len(functions)} functions and {len(cases)} cases and {len(supplements)} supplements and {(len(dialects_lib.dialects))} dialects"
     )
-
     for func in functions:
         matching_cases = [case for case in cases if case.function == func.name]
         supplement = supplements.get(func.name, None)
         if supplement is None:
             supplement = empty_supplements_file(func.name)
         print(f"Creating site for {func.name}")
-        info = create_function_info(
-            func, matching_cases, supplement, dialects_lib, function_file
-        )
+        info = create_function_info(func, matching_cases, supplement, dialects_lib)
         out_path = pathlib.Path(dest_dir) / f"{func.name}.html"
         with open(out_path, mode="w") as out:
             out.write(render_scalar_function(info))

--- a/bft/html/types.py
+++ b/bft/html/types.py
@@ -129,8 +129,6 @@ class FunctionIndexItem(NamedTuple):
     name: str
     # Summary of the function, sourced from Substrait YAML
     brief: str
-    # Whether documentation exists for the function yet
-    enabled: bool
 
 
 class FunctionIndexInfo(NamedTuple):

--- a/bft/substrait/extension_file_parser.py
+++ b/bft/substrait/extension_file_parser.py
@@ -1,3 +1,4 @@
+import pathlib
 from collections import namedtuple
 from collections.abc import Iterable
 from typing import Dict, List, NamedTuple
@@ -124,9 +125,12 @@ class ExtensionFileParser(object):
         return ExtensionFileVisitor().visit_ext_file(data)
 
 
-def add_extensions_file_to_library(ext_file: ExtensionsFile, library: LibraryBuilder):
+def add_extensions_file_to_library(
+    location: str, ext_file: ExtensionsFile, library: LibraryBuilder
+):
     for scalar_func in ext_file.scalar_functions:
         builder: FunctionBuilder = library.get_function(scalar_func.name)
+        builder.set_uri(pathlib.Path(location).name)
         if scalar_func.description is not None:
             builder.try_set_description(scalar_func.description)
         for impl in scalar_func.implementations:

--- a/bft/templates/function_index.j2
+++ b/bft/templates/function_index.j2
@@ -32,11 +32,7 @@
             <dl>
                 {% for function in functions %}
                 <dt>
-                    {% if function.enabled %}
                     <a href="./{{function.name|lower}}.html">{{function.name|title}}</a>
-                    {% else %}
-                    <a class="disabled" aria-disabled="true">{{function.name|title}}</a>
-                    {% endif %}
                 </dt>
                 <dd>{{function.brief}}</dd>
                 {% endfor %}


### PR DESCRIPTION
- Remove the `enabled` flag from class `FunctionIndexItem`, since now all the functions have some information anyway so all the pages should be generated
- Fix the URI resolution in function `create_function_info` for both the short uri (extension file names) and the long ones (from the `substrait` repository)