### PR TITLE
feat: add support for datetime functions in cudf backend

### DIFF
--- a/dialects/cudf.yaml
+++ b/dialects/cudf.yaml
@@ -152,6 +152,26 @@ scalar_functions:
   - name: ceil
   - name: floor
   - name: round
+  - name: extract
+    extract: True
+  - name: add_datetime
+    unsupported: True
+  - name: add_intervals
+    unsupported: True
+  - name: subtract_datetime
+    unsupported: True
+  - name: lt_datetime
+    local_name: "<"
+    infix: True
+  - name: lte_datetime
+    local_name: "<="
+    infix: True
+  - name: gt_datetime
+    local_name: ">"
+    infix: True
+  - name: gt_datetime
+    local_name: ">="
+    infix: True
   - name: substring
     unsupported: True
   - name: concat


### PR DESCRIPTION
This PR adds support for some of the datetime function tests to the cudf backend.

Most test failure are due to cudf not having support for the data types being tested.