### PR TITLE
fix: postgres and datafusion ci failures

### DIFF
--- a/bft/testers/datafusion/runner.py
+++ b/bft/testers/datafusion/runner.py
@@ -150,6 +150,9 @@ class DatafusionRunner(SqlCaseRunner):
             elif case.result == "nan":
                 if math.isnan(result):
                     return SqlCaseResult.success()
+            elif case.result.type.startswith('fp') and case.result.value:
+                if math.isclose(result, case.result.value, rel_tol=1e-6):
+                    return SqlCaseResult.success()
             else:
                 if result == case.result.value:
                     return SqlCaseResult.success()

--- a/bft/testers/datafusion/runner.py
+++ b/bft/testers/datafusion/runner.py
@@ -150,6 +150,11 @@ class DatafusionRunner(SqlCaseRunner):
             elif case.result == "nan":
                 if math.isnan(result):
                     return SqlCaseResult.success()
+            # Issues with python float comparison:
+            # https://tutorpython.com/python-mathisclose/#The_problem_with_using_for_float_comparison
+            # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+            # Datafusion bug with float when converting from a dataframe to a pylist:
+            # https://github.com/apache/arrow-datafusion/issues/9950
             elif case.result.type.startswith('fp') and case.result.value:
                 if math.isclose(result, case.result.value, rel_tol=1e-6):
                     return SqlCaseResult.success()

--- a/bft/testers/postgres/runner.py
+++ b/bft/testers/postgres/runner.py
@@ -141,7 +141,7 @@ class PostgresRunner(SqlCaseRunner):
                 print(f"Expected NAN but received {result}")
                 return SqlCaseResult.error(str(result))
             elif case.result.type.startswith("fp") and case.result.value:
-                if math.isclose(result, case.result.value, rel_tol=1e-9):
+                if math.isclose(result, case.result.value, rel_tol=1e-8):
                     return SqlCaseResult.success()
             else:
                 if result == case.result.value:

--- a/bft/testers/postgres/runner.py
+++ b/bft/testers/postgres/runner.py
@@ -141,7 +141,7 @@ class PostgresRunner(SqlCaseRunner):
                 print(f"Expected NAN but received {result}")
                 return SqlCaseResult.error(str(result))
             elif case.result.type.startswith("fp") and case.result.value:
-                if math.isclose(result, case.result.value, rel_tol=1e-8):
+                if math.isclose(result, case.result.value, rel_tol=1e-7):
                     return SqlCaseResult.success()
             else:
                 if result == case.result.value:

--- a/bft/testers/postgres/runner.py
+++ b/bft/testers/postgres/runner.py
@@ -141,7 +141,7 @@ class PostgresRunner(SqlCaseRunner):
                 print(f"Expected NAN but received {result}")
                 return SqlCaseResult.error(str(result))
             elif case.result.type.startswith("fp") and case.result.value:
-                if math.isclose(result, case.result.value, rel_tol=1e-6):
+                if math.isclose(result, case.result.value, rel_tol=1e-9):
                     return SqlCaseResult.success()
             else:
                 if result == case.result.value:

--- a/bft/testers/postgres/runner.py
+++ b/bft/testers/postgres/runner.py
@@ -140,6 +140,9 @@ class PostgresRunner(SqlCaseRunner):
             elif case.result == "nan":
                 print(f"Expected NAN but received {result}")
                 return SqlCaseResult.error(str(result))
+            # Issues with python float comparison:
+            # https://tutorpython.com/python-mathisclose/#The_problem_with_using_for_float_comparison
+            # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
             elif case.result.type.startswith("fp") and case.result.value:
                 if math.isclose(result, case.result.value, rel_tol=1e-7):
                     return SqlCaseResult.success()

--- a/bft/testers/postgres/runner.py
+++ b/bft/testers/postgres/runner.py
@@ -1,11 +1,11 @@
 import datetime
+import math
 import os
-from typing import Dict, NamedTuple
 
 import psycopg
 
 from bft.cases.runner import SqlCaseResult, SqlCaseRunner
-from bft.cases.types import Case, CaseLiteral
+from bft.cases.types import Case
 from bft.dialects.types import SqlMapping
 
 type_map = {
@@ -38,7 +38,6 @@ def literal_to_str(lit: str | int | float):
     elif lit in [float("-inf"), "-inf"]:
         return "'-Infinity'"
     return str(lit)
-
 
 
 def is_string_type(arg):
@@ -141,6 +140,9 @@ class PostgresRunner(SqlCaseRunner):
             elif case.result == "nan":
                 print(f"Expected NAN but received {result}")
                 return SqlCaseResult.error(str(result))
+            elif case.result.type.startswith("fp") and case.result.value:
+                if math.isclose(result, case.result.value, rel_tol=1e-6):
+                    return SqlCaseResult.success()
             else:
                 if result == case.result.value:
                     return SqlCaseResult.success()

--- a/cases/arithmetic/abs.yaml
+++ b/cases/arithmetic/abs.yaml
@@ -32,10 +32,10 @@ cases:
       type: i64
   - group: basic
     args:
-      - value: 2.5499999523162841796875
+      - value: 2.55
         type: fp32
     result:
-      value: 2.5499999523162841796875
+      value: 2.55
       type: fp32
   - group: basic
     args:

--- a/cases/arithmetic/atanh.yaml
+++ b/cases/arithmetic/atanh.yaml
@@ -19,14 +19,14 @@ cases:
   - group: basic
     args:
       - value: 0.009
-        type: fp64
+        type: fp32
     result:
       value: 0.009000243011810481
       type: fp64
   - group: basic
     args:
       - value: -0.009
-        type: fp64
+        type: fp32
     result:
       value: -0.009000243011810481
       type: fp64

--- a/dialects/datafusion.yaml
+++ b/dialects/datafusion.yaml
@@ -6,7 +6,6 @@ scalar_functions:
     infix: True
     required_options:
       overflow: SILENT
-      rounding: TIE_TO_EVEN
   - name: subtract
     local_name: "-"
     infix: True
@@ -44,10 +43,6 @@ scalar_functions:
       on_domain_error: ERROR
   - name: exp
     local_name: exp
-    unsupported_kernels:
-      - args:
-          - fp32
-        result: fp32
     required_options:
       rounding: TIE_TO_EVEN
   - name: cos
@@ -79,10 +74,6 @@ scalar_functions:
     required_options:
       rounding: TIE_TO_EVEN
       on_domain_error: NAN
-    unsupported_kernels:
-      - args:
-          - fp32
-        result: fp32
   - name: asin
     local_name: asin
     required_options:
@@ -101,10 +92,6 @@ scalar_functions:
     local_name: asinh
     required_options:
       rounding: TIE_TO_EVEN
-    unsupported_kernels:
-      - args:
-          - fp32
-        result: fp32
   - name: atanh
     local_name: atanh
     required_options:

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -12,10 +12,6 @@ scalar_functions:
           - i8
           - i8
         result: i8
-      - args:
-          - fp32
-          - fp32
-        result: fp32
   - name: subtract
     local_name: "-"
     infix: True

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -6,7 +6,6 @@ scalar_functions:
     infix: True
     required_options:
       overflow: ERROR
-      rounding: TIE_TO_EVEN
     unsupported_kernels:
       - args:
           - i8


### PR DESCRIPTION
Postgres CI was failing due to a typing issue in the abs test cases.  After fixing this, a bunch of datafusion rounding issues came up.  This PR addresses some of those as well.  

* When converting the datafusion dataframe result into a python result, fp32 results get get to a python float , which is double , and in some cases the conversation creates a result with many more significant digits.