### PR TITLE
fix: update tests to reflect duckdb +/- datetime bug fix

### DIFF
--- a/bft/testers/duckdb/runner.py
+++ b/bft/testers/duckdb/runner.py
@@ -125,6 +125,12 @@ class DuckDBRunner(SqlCaseRunner):
                 return SqlCaseResult.success()
             elif case.result == "error":
                 return SqlCaseResult.unexpected_pass(str(result))
+            # Issues with python float comparison:
+            # https://tutorpython.com/python-mathisclose/#The_problem_with_using_for_float_comparison
+            # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+            elif case.result.type.startswith("fp") and case.result.value and result:
+                if math.isclose(result, case.result.value, rel_tol=1e-7):
+                    return SqlCaseResult.success()
             else:
                 if result == case.result.value:
                     return SqlCaseResult.success()

--- a/cases/arithmetic/add.yaml
+++ b/cases/arithmetic/add.yaml
@@ -145,17 +145,6 @@ cases:
     result:
       value: 7.00000095367431640625
       type: fp32
-  - group: rounding
-    args:
-      - value: 4.5
-        type: fp32
-      - value: 2.5000007152557373046875
-        type: fp32
-    options:
-      rounding: FLOOR
-    result:
-      value: 7.000000476837158203125
-      type: fp32
   - group:
       id: types
       description: Examples demonstrating behavior of different data types

--- a/cases/arithmetic/factorial.yaml
+++ b/cases/arithmetic/factorial.yaml
@@ -5,31 +5,31 @@ cases:
       description: Basic examples without any special cases
     args:
       - value: 0
-        type: i8
+        type: i32
     result:
       value: 1
-      type: i8
+      type: i32
   - group: basic
     args:
       - value: 1
-        type: i8
+        type: i32
     result:
       value: 1
-      type: i8
+      type: i32
   - group: basic
     args:
       - value: 20
-        type: i8
+        type: i64
     result:
       value: 2432902008176640000
       type: i64
   - group: basic
     args:
       - value: null
-        type: i8
+        type: i32
     result:
       value: null
-      type: i8
+      type: i32
   - group:
       id: overflow
       description: Examples demonstrating overflow behavior

--- a/cases/arithmetic/factorial.yaml
+++ b/cases/arithmetic/factorial.yaml
@@ -5,37 +5,37 @@ cases:
       description: Basic examples without any special cases
     args:
       - value: 0
-        type: i32
+        type: i8
     result:
       value: 1
-      type: i32
+      type: i8
   - group: basic
     args:
       - value: 1
-        type: i64
+        type: i8
     result:
       value: 1
-      type: i64
+      type: i8
   - group: basic
     args:
       - value: 20
-        type: i64
+        type: i8
     result:
       value: 2432902008176640000
       type: i64
   - group: basic
     args:
       - value: null
-        type: i64
+        type: i8
     result:
       value: null
-      type: i64
+      type: i8
   - group:
       id: overflow
       description: Examples demonstrating overflow behavior
     args:
       - value: 1000000
-        type: i64
+        type: i32
     options:
       overflow: ERROR
     result:

--- a/cases/datetime/add_datetime.yaml
+++ b/cases/datetime/add_datetime.yaml
@@ -30,73 +30,34 @@ cases:
       value: '2016-12-01 18:30:15'
       type: timestamp
   - group:
-      id: date
-      description: examples using the date types
+      id: date_to_timestamp
+      description: examples using the date types and resulting in a timestamp
     args:
       - value: '2020-12-31'
         type: date
       - value: INTERVAL '5 DAY'
         type: interval
-    options:
-      with_time: FALSE
-    result:
-      value: '2021-01-05'
-      type: date
-  - group: date
-    args:
-      - value: '2020-12-31'
-        type: date
-      - value: INTERVAL '5 YEAR'
-        type: interval
-    options:
-      with_time: FALSE
-    result:
-      value: '2025-12-31'
-      type: date
-  - group: date
-    args:
-      - value: '2020-12-31'
-        type: date
-      - value: INTERVAL '5 MONTH'
-        type: interval
-    options:
-      with_time: FALSE
-    result:
-      value: '2021-05-31'
-      type: date
-  - group: date
-    args:
-      - value: '2020-12-31'
-        type: date
-      - value: INTERVAL '5 DAY'
-        type: interval
-    options:
-      with_time: TRUE
     result:
       value: '2021-01-05 00:00:00'
-      type: date
-  - group: date
+      type: timestamp
+  - group: date_to_timestamp
     args:
       - value: '2020-12-31 '
         type: date
       - value: INTERVAL '5 YEAR'
         type: interval
-    options:
-      with_time: TRUE
     result:
       value: '2025-12-31 00:00:00'
-      type: date
-  - group: date
+      type: timestamp
+  - group: date_to_timestamp
     args:
       - value: '2020-12-31'
         type: date
       - value: INTERVAL '5 MONTH'
         type: interval
-    options:
-      with_time: TRUE
     result:
       value: '2021-05-31 00:00:00'
-      type: date
+      type: timestamp
   - group:
       id: null_input
       description: examples with null args or return

--- a/cases/datetime/subtract_datetime.yaml
+++ b/cases/datetime/subtract_datetime.yaml
@@ -30,73 +30,34 @@ cases:
       value: '2016-12-01 08:30:15'
       type: timestamp
   - group:
-      id: date
-      description: examples using the date types
+      id: date_to_timestamp
+      description: examples using the date types and resulting in a timestamp
     args:
       - value: '2020-12-31'
         type: date
       - value: INTERVAL '5 DAY'
         type: interval
-    options:
-      with_time: FALSE
-    result:
-      value: '2020-12-26'
-      type: date
-  - group: date
-    args:
-      - value: '2020-12-31'
-        type: date
-      - value: INTERVAL '5 YEAR'
-        type: interval
-    options:
-      with_time: FALSE
-    result:
-      value: '2015-12-31'
-      type: date
-  - group: date
-    args:
-      - value: '2020-12-31'
-        type: date
-      - value: INTERVAL '5 MONTH'
-        type: interval
-    options:
-      with_time: FALSE
-    result:
-      value: '2020-07-31'
-      type: date
-  - group: date
-    args:
-      - value: '2020-12-31'
-        type: date
-      - value: INTERVAL '5 DAY'
-        type: interval
-    options:
-      with_time: TRUE
     result:
       value: '2020-12-26 00:00:00'
-      type: date
-  - group: date
+      type: timestamp
+  - group: date_to_timestamp
     args:
       - value: '2020-12-31'
         type: date
       - value: INTERVAL '5 YEAR'
         type: interval
-    options:
-      with_time: TRUE
     result:
       value: '2015-12-31 00:00:00'
-      type: date
-  - group: date
+      type: timestamp
+  - group: date_to_timestamp
     args:
       - value: '2020-12-31'
         type: date
       - value: INTERVAL '5 MONTH'
         type: interval
-    options:
-      with_time: TRUE
     result:
       value: '2020-07-31 00:00:00'
-      type: date
+      type: timestamp
   - group:
       id: null_input
       description: examples with null args or return

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -108,9 +108,6 @@ scalar_functions:
       overflow: ERROR
     unsupported_kernels:
       - args:
-          - i64
-        result: i64
-      - args:
           - fp32
         result: fp32
       - args:

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -183,11 +183,6 @@ scalar_functions:
   - name: ceil
   - name: floor
   - name: round
-    unsupported_kernels:
-      - args:
-          - fp32
-          - i8
-        result: fp32
   - name: extract
     extract: True
   - name: add_datetime

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -199,8 +199,6 @@ scalar_functions:
   - name: add_datetime
     local_name: +
     infix: True
-    required_options:
-      with_time: FALSE
   - name: add_intervals
     local_name: +
     infix: True

--- a/dialects/duckdb.yaml
+++ b/dialects/duckdb.yaml
@@ -108,11 +108,8 @@ scalar_functions:
       overflow: ERROR
     unsupported_kernels:
       - args:
-          - fp32
-        result: fp32
-      - args:
-          - fp64
-        result: fp64
+          - i64
+        result: i64
   - name: abs
     local_name: abs
     required_options:

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -409,8 +409,6 @@ scalar_functions:
   - name: add_datetime
     local_name: +
     infix: True
-    required_options:
-      with_time: TRUE
   - name: add_intervals
     local_name: +
     infix: True

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -167,6 +167,10 @@ scalar_functions:
     infix: False
     required_options:
       overflow: ERROR
+    unsupported_kernels:
+      - args:
+          - i8
+        result: i8
   - name: abs
     local_name: abs
     infix: False

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -171,6 +171,9 @@ scalar_functions:
       - args:
           - i8
         result: i8
+      - args:
+          - i8
+        result: i64
   - name: abs
     local_name: abs
     infix: False


### PR DESCRIPTION
Duckdb was previously (incorrectly) adding date + interval -> date.

They've fixed this so that date + interval -> timestamp.  This now aligns with other engines.