### PR TITLE
fix: inconsistency between inf, infinitiy, 'inf' in test args

### DIFF
--- a/cases/arithmetic/divide.yaml
+++ b/cases/arithmetic/divide.yaml
@@ -70,7 +70,7 @@ cases:
     options:
       on_division_by_zero: LIMIT
     result:
-      value: Infinity
+      value: inf
       type: fp64
   - group:
       id: overflow
@@ -104,7 +104,7 @@ cases:
       - value: 1.5e-200
         type: fp64
     result:
-      value: Infinity
+      value: inf
       type: fp64
   - group: floating_exception
     args:
@@ -113,5 +113,5 @@ cases:
       - value: -1.5e-208
         type: fp64
     result:
-      value: -Infinity
+      value: -inf
       type: fp64

--- a/cases/arithmetic/max.yaml
+++ b/cases/arithmetic/max.yaml
@@ -53,14 +53,14 @@ cases:
       type: fp64
   - group: basic
     args:
-      - value: [Null, "inf", -1.5e+8, -1.5e+7, -1.5e+70]
+      - value: [Null, inf, -1.5e+8, -1.5e+7, -1.5e+70]
         type: fp64
     result:
       value: inf
       type: fp64
   - group: basic
     args:
-      - value: [Null, "-inf"]
+      - value: [Null, -inf]
         type: fp64
     result:
       value: -inf

--- a/cases/arithmetic/min.yaml
+++ b/cases/arithmetic/min.yaml
@@ -53,14 +53,14 @@ cases:
       type: fp64
   - group: basic
     args:
-      - value: [Null, "-inf", -1.5e+8, -1.5e+7, -1.5e+70]
+      - value: [Null, -inf, -1.5e+8, -1.5e+7, -1.5e+70]
         type: fp64
     result:
       value: -inf
       type: fp64
   - group: basic
     args:
-      - value: [Null, "inf"]
+      - value: [Null, inf]
         type: fp64
     result:
       value: inf

--- a/cases/arithmetic/multiply.yaml
+++ b/cases/arithmetic/multiply.yaml
@@ -121,7 +121,7 @@ cases:
       - value: 1.5e+208
         type: fp64
     result:
-      value: Infinity
+      value: inf
       type: fp64
   - group: floating_exception
     args:
@@ -130,7 +130,7 @@ cases:
       - value: -1.5e+208
         type: fp64
     result:
-      value: -Infinity
+      value: -inf
       type: fp64
   - group:
       id: types

--- a/cases/arithmetic/negate.yaml
+++ b/cases/arithmetic/negate.yaml
@@ -46,10 +46,10 @@ cases:
       type: fp64
   - group: basic
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
     result:
-      value: -Infinity
+      value: -inf
       type: fp64
   - group:
       id: null_input

--- a/cases/arithmetic/power.yaml
+++ b/cases/arithmetic/power.yaml
@@ -47,5 +47,5 @@ cases:
       - value: 1.5e+208
         type: fp64
     result:
-      value: Infinity
+      value: inf
       type: fp64

--- a/cases/arithmetic/sum.yaml
+++ b/cases/arithmetic/sum.yaml
@@ -74,14 +74,14 @@ cases:
       type: fp64
   - group: basic
     args:
-      - value: [2.500000715, "inf", 2.500000715]
+      - value: [2.500000715, inf, 2.500000715]
         type: fp64
     result:
       value: inf
       type: fp64
   - group: basic
     args:
-      - value: [2.5000007, "-inf", 2.5000007, 10.0]
+      - value: [2.5000007, -inf, 2.5000007, 10.0]
         type: fp64
     result:
       value: -inf

--- a/cases/comparison/equal.yaml
+++ b/cases/comparison/equal.yaml
@@ -33,27 +33,27 @@ cases:
       id: null_input
       description: Examples with null as input
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
-      - value: Infinity
-        type: fp64
-    result:
-      value: true
-      type: boolean
-  - group: basic
-    args:
-      - value: -Infinity
-        type: fp64
-      - value: -Infinity
+      - value: inf
         type: fp64
     result:
       value: true
       type: boolean
   - group: basic
     args:
-      - value: -Infinity
+      - value: -inf
         type: fp64
-      - value: Infinity
+      - value: -inf
+        type: fp64
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: -inf
+        type: fp64
+      - value: inf
         type: fp64
     result:
       value: False

--- a/cases/comparison/gt.yaml
+++ b/cases/comparison/gt.yaml
@@ -42,7 +42,7 @@ cases:
       id: null_input
       description: Examples with null as input
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
       - value: 1.5e+308
         type: fp64
@@ -53,7 +53,7 @@ cases:
     args:
       - value: -1.5e+308
         type: fp64
-      - value: -Infinity
+      - value: -inf
         type: fp64
     result:
       value: true

--- a/cases/comparison/gte.yaml
+++ b/cases/comparison/gte.yaml
@@ -49,7 +49,7 @@ cases:
       type: boolean
   - group: basic
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
       - value: 1.5e+308
         type: fp64
@@ -58,16 +58,16 @@ cases:
       type: boolean
   - group: basic
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
-      - value: Infinity
+      - value: inf
         type: fp64
     result:
       value: true
       type: boolean
   - group: basic
     args:
-      - value: -Infinity
+      - value: -inf
         type: fp64
       - value: -1.5e+308
         type: fp64

--- a/cases/comparison/lt.yaml
+++ b/cases/comparison/lt.yaml
@@ -42,7 +42,7 @@ cases:
     args:
       - value: 1.5e+308
         type: fp64
-      - value: Infinity
+      - value: inf
         type: fp64
     result:
       value: true
@@ -51,7 +51,7 @@ cases:
     args:
       - value: -1.5e+308
         type: fp64
-      - value: -Infinity
+      - value: -inf
         type: fp64
     result:
       value: false

--- a/cases/comparison/lte.yaml
+++ b/cases/comparison/lte.yaml
@@ -51,16 +51,16 @@ cases:
     args:
       - value: 1.5e+308
         type: fp64
-      - value: Infinity
+      - value: inf
         type: fp64
     result:
       value: true
       type: boolean
   - group: basic
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
-      - value: Infinity
+      - value: inf
         type: fp64
     result:
       value: true
@@ -69,7 +69,7 @@ cases:
     args:
       - value: -1.5e+308
         type: fp64
-      - value: -Infinity
+      - value: -inf
         type: fp64
     result:
       value: false

--- a/cases/comparison/not_equal.yaml
+++ b/cases/comparison/not_equal.yaml
@@ -22,16 +22,16 @@ cases:
       type: boolean
   - group: basic
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
-      - value: Infinity
+      - value: inf
         type: fp64
     result:
       value: false
       type: boolean
   - group: basic
     args:
-      - value: Infinity
+      - value: inf
         type: fp64
       - value: 1.5e+308
         type: fp64


### PR DESCRIPTION
This PR fixes inconsistency where 3 different kinds of infinity type arguments were being used
inf, Infinity, "inf" are all now replaces with inf