### PR TITLE
fix: display aggregate function examples on bft site

### DIFF
--- a/bft/html/builder.py
+++ b/bft/html/builder.py
@@ -186,10 +186,7 @@ def create_function_info(
     supplements: SupplementsFile,
     dialects: DialectsLibrary,
 ) -> FunctionInfo:
-    if func.name.startswith('aggregate'):
-        name = "_".join(func.name.split('_')[2:])
-    else:
-        name = "_".join(func.name.split('_')[1:])
+    name = find_simplified_name(func.name)
     uri_short = func.uri
     uri = "https://github.com/substrait-io/substrait/blob/main/extensions/" + uri_short
     brief = func.description
@@ -231,6 +228,14 @@ def create_function_index(
     return FunctionIndexInfo(items)
 
 
+def find_simplified_name(name: str) -> str:
+    if name.startswith('aggregate'):
+        func_name_full = "_".join(name.split('_')[2:])
+    else:
+        func_name_full = "_".join(name.split('_')[1:])
+    return func_name_full
+
+
 def build_site(index_path: str, dest_dir):
     root = pathlib.Path(index_path).parent
     index_contents = load_index(index_path)
@@ -265,10 +270,7 @@ def build_site(index_path: str, dest_dir):
         f"There are {len(functions)} functions and {len(cases)} cases and {len(supplements)} supplements and {(len(dialects_lib.dialects))} dialects"
     )
     for func in functions:
-        if func.name.startswith('aggregate'):
-            func_name_full = "_".join(func.name.split('_')[2:])
-        else:
-            func_name_full = "_".join(func.name.split('_')[1:])
+        func_name_full = find_simplified_name(func.name)
         matching_cases = [case for case in cases if case.function == func_name_full]
         supplement = supplements.get(func_name_full, None)
         if supplement is None:

--- a/bft/html/builder.py
+++ b/bft/html/builder.py
@@ -186,7 +186,10 @@ def create_function_info(
     supplements: SupplementsFile,
     dialects: DialectsLibrary,
 ) -> FunctionInfo:
-    name = "_".join(func.name.split('_')[1:])
+    if func.name.startswith('aggregate'):
+        name = "_".join(func.name.split('_')[2:])
+    else:
+        name = "_".join(func.name.split('_')[1:])
     uri_short = func.uri
     uri = "https://github.com/substrait-io/substrait/blob/main/extensions/" + uri_short
     brief = func.description
@@ -262,7 +265,10 @@ def build_site(index_path: str, dest_dir):
         f"There are {len(functions)} functions and {len(cases)} cases and {len(supplements)} supplements and {(len(dialects_lib.dialects))} dialects"
     )
     for func in functions:
-        func_name_full = "_".join(func.name.split('_')[1:])
+        if func.name.startswith('aggregate'):
+            func_name_full = "_".join(func.name.split('_')[2:])
+        else:
+            func_name_full = "_".join(func.name.split('_')[1:])
         matching_cases = [case for case in cases if case.function == func_name_full]
         supplement = supplements.get(func_name_full, None)
         if supplement is None:

--- a/bft/templates/function_desc.j2
+++ b/bft/templates/function_desc.j2
@@ -6,7 +6,11 @@
     <title>{{ name }} Function - BFT</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Reference for the {{ "_".join(name.split('_')[1:]) }} function">
+    {% if 'aggregate' in name %}
+        <meta name="description" content="Reference for the {{ "_".join(name.split('_')[2:]) }} function">
+    {% else %}
+        <meta name="description" content="Reference for the {{ "_".join(name.split('_')[1:]) }} function">
+    {% endif %}
     <link rel="stylesheet" href="./assets/supplementary/terminal.css">
     <link rel="stylesheet" href="./assets/supplementary/style.css">
 </head>

--- a/bft/templates/function_index.j2
+++ b/bft/templates/function_index.j2
@@ -90,8 +90,13 @@
                                 <tbody>
                                     {% for function in category_functions %}
                                         <tr onclick="window.location='./{{ function.name|lower }}.html';" style="cursor: pointer;">
-                                            <td class="title-column">{{ "_".join(function.name.split('_')[1:])|title }}</td>
-                                            <td>{{ function.brief }}</td>
+                                            {% if 'aggregate' in function.name %}
+                                                <td class="title-column">{{ "_".join(function.name.split('_')[2:])|title }}</td>
+                                                <td>{{ function.brief }}</td>
+                                            {% else %}
+                                                <td class="title-column">{{ "_".join(function.name.split('_')[1:])|title }}</td>
+                                                <td>{{ function.brief }}</td>
+                                            {% endif %}
                                         </tr>
                                     {% endfor %}
                                 </tbody>

--- a/cases/aggregate_generic/count.yaml
+++ b/cases/aggregate_generic/count.yaml
@@ -8,32 +8,32 @@ cases:
         type: i16
     result:
       value: 6
-      type: i16
+      type: i64
   - group: basic
     args:
       - value: [1000]
         type: i16
     result:
       value: 1
-      type: i16
+      type: i64
   - group: basic
     args:
       - value: []
         type: i16
     result:
       value: 0
-      type: i16
+      type: i64
   - group: basic
     args:
       - value: [Null, Null, Null]
         type: i16
     result:
       value: 0
-      type: i16
+      type: i64
   - group: basic
     args:
       - value: [Null, Null, Null, 1000]
         type: i16
     result:
       value: 1
-      type: i16
+      type: i64


### PR DESCRIPTION
The functions listed under https://substrait.io/extensions/functions_aggregate_generic/

Aren't displaying properly on the bft site. Examples aren't being populated
due to a naming mismatch: https://voltrondata.github.io/bft/aggregate_generic_count.html

Fix return of count function to match substrait