### PR TITLE
Add test case for Logb function

### DIFF
--- a/bft/cases/runner.py
+++ b/bft/cases/runner.py
@@ -71,7 +71,11 @@ class SqlCaseRunner(CaseRunner):
         elif result.type == "error":
             if case.result == "error":
                 # Case expected to error.  Dialect may or may not have expected it
-                return CaseResult(True, mapping.should_pass, mapping.reason)
+                should_pass = mapping.should_pass
+                if mapping.unsupported:
+                    # Unsupported test case, expected an error and got an error
+                    should_pass = True
+                return CaseResult(True, should_pass, mapping.reason)
             else:
                 if mapping.should_pass:
                     # Case should not have error.  Dialect should not have error

--- a/bft/dialects/types.py
+++ b/bft/dialects/types.py
@@ -212,7 +212,7 @@ class Dialect(object):
                 dfunc.postfix,
                 dfunc.between,
                 dfunc.aggregate,
-                dfunc.unsupported,
+                True,
                 dfunc.extract,
                 False,
                 kernel_failure,

--- a/cases/logarithmic/logb.yaml
+++ b/cases/logarithmic/logb.yaml
@@ -1,0 +1,108 @@
+base_uri: https://github.com/substrait-io/substrait/blob/main/extensions/substrait/extensions/functions_logarithmic.yaml
+function: logb
+cases:
+  - group:
+      id: basic
+      description: Basic examples without any special cases
+    args:
+      - value: 10
+        type: i64
+      - value: 100000
+        type: i64
+    result:
+      value: 5.0
+      type: fp64
+  - group: basic
+    args:
+      - value: 7
+        type: fp64
+      - value: 1.0
+        type: fp64
+    result:
+      value: 0
+      type: fp64
+  - group: basic
+    args:
+      - value: 2
+        type: fp64
+      - value: 7
+        type: fp64
+    result:
+      value: 2.8073549220576041
+      type: fp64
+  - group:
+      id: infinity
+      description: Examples with infinity as input
+    args:
+      - value: 2.34
+        type: fp64
+      - value: inf
+        type: fp64
+    result:
+      value: inf
+      type: fp64
+  - group: infinity
+    args:
+      - value: 10
+        type: fp64
+      - value: -inf
+        type: fp64
+    options:
+      on_domain_error: ERROR
+    result:
+      special: error
+  - group: infinity
+    args:
+      - value: 10
+        type: fp64
+      - value: -inf
+        type: fp64
+    options:
+      on_domain_error: NAN
+    result:
+      special: nan
+  - group: infinity
+    args:
+      - value: 10
+        type: fp64
+      - value: -inf
+        type: fp64
+    options:
+      on_domain_error: NONE
+    result:
+      value: null
+      type: fp64
+  - group:
+      id: log_zero
+      description: Examples with log zero
+    args:
+      - value: 2.0
+        type: fp64
+      - value: 0.0
+        type: fp64
+    options:
+      on_log_zero: ERROR
+    result:
+      special: error
+  - group: log_zero
+    args:
+      - value: 2.0
+        type: fp64
+      - value: 0.0
+        type: fp64
+    options:
+      on_log_zero: NAN
+    result:
+      value: null
+      type: fp64
+  - group: log_zero
+    args:
+      - value: 2.0
+        type: fp64
+      - value: 0.0
+        type: fp64
+    options:
+      on_log_zero: MINUS_INFINITY
+    result:
+      value: -inf
+      type: fp64

--- a/dialects/datafusion.yaml
+++ b/dialects/datafusion.yaml
@@ -529,6 +529,14 @@ scalar_functions:
   - i64
   - fp32
   - fp64
+- name: logarithmic.logb
+  local_name: log
+  required_options:
+    on_log_zero: MINUS_INFINITY
+    on_domain_error: NAN
+  supported_kernels:
+  - i64_i64
+  - fp64_fp64
 aggregate_functions:
 - name: arithmetic.min
   aggregate: true

--- a/dialects/postgres.yaml
+++ b/dialects/postgres.yaml
@@ -614,6 +614,13 @@ scalar_functions:
   - i64
   - fp32
   - fp64
+- name: logarithmic.logb
+  local_name: log
+  required_options:
+    on_log_zero: ERROR
+    on_domain_error: ERROR
+  supported_kernels:
+  - i64_i64
 aggregate_functions:
 - name: arithmetic.min
   aggregate: true

--- a/dialects/snowflake.yaml
+++ b/dialects/snowflake.yaml
@@ -322,6 +322,13 @@ scalar_functions:
     on_domain_error: ERROR
   supported_kernels:
   - fp64
+- name: logarithmic.logb
+  local_name: log
+  required_options:
+    on_log_zero: ERROR
+    on_domain_error: ERROR
+  supported_kernels:
+  - fp64_fp64
 aggregate_functions:
 - name: arithmetic.min
   aggregate: true

--- a/dialects/sqlite.yaml
+++ b/dialects/sqlite.yaml
@@ -451,6 +451,14 @@ scalar_functions:
   - i64
   - fp32
   - fp64
+- name: logarithmic.logb
+  local_name: log
+  required_options:
+    on_log_zero: NAN
+    on_domain_error: NONE
+  supported_kernels:
+  - i64_i64
+  - fp64_fp64
 aggregate_functions:
 - name: arithmetic.min
   aggregate: true


### PR DESCRIPTION
* Added logb function test case
* duckdb, Velox, cudf doesn't support it. So skipped adding these dialects
* Also, fixed handling of unsupported_kernel if expected result is an error. Issue observed is as below, 
postgres supports fp64 datatype (i.e. float8 in postgres). But postgres log function doesn't support fp64 arguments. so a test expecting fp64 argument and return type error would fail even if posgres returned error.
* In other words, for unsupported kernel in a function, if test case expected error and dialect returned error then "should_Pass" should be true. But way exising code is, "should_pass" was considered false for unsupported kernel ([here](https://github.com/voltrondata/bft/blob/98d418fa18aec8b3bd1d43f7806e35e9b2013b87/bft/dialects/types.py#L217))
