### PR TITLE
chore: remove submodule before repo donation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "substrait"]
-	path = substrait
-	url = https://github.com/substrait-io/substrait.git


### PR DESCRIPTION
Removing the substrait submodule prior to repo donation to the substrait project.

Substrait submodule will be added back after the donation.