### PR TITLE
Add test cases for comparison functions with decimal arguments

### DIFF
--- a/bft/testers/cudf/runner.py
+++ b/bft/testers/cudf/runner.py
@@ -7,6 +7,7 @@ import numpy
 from bft.cases.runner import SqlCaseResult, SqlCaseRunner
 from bft.cases.types import Case
 from bft.dialects.types import SqlMapping
+from bft.utils.utils import type_to_dialect_type
 
 type_map = {
     "i8": cudf.dtype("int8"),
@@ -23,9 +24,7 @@ type_map = {
 
 
 def type_to_cudf_dtype(type: str):
-    if type not in type_map:
-        raise Exception(f"Unrecognized type: {type}")
-    return type_map[type]
+    return type_to_dialect_type(type, type_map)
 
 
 def is_string_function(data_types):

--- a/bft/testers/duckdb/runner_test.py
+++ b/bft/testers/duckdb/runner_test.py
@@ -4,3 +4,4 @@ from bft.testers.duckdb.runner import type_to_duckdb_type
 def test_type_to_duckdb_type():
     assert type_to_duckdb_type("interval") == "INTERVAL"
     assert type_to_duckdb_type("decimal<37, 3>") == "DECIMAL(37, 3)"
+    assert type_to_duckdb_type("non_existent") is None

--- a/bft/utils/utils.py
+++ b/bft/utils/utils.py
@@ -18,7 +18,7 @@ def type_to_dialect_type(type: str, type_map: Dict[str, str])->str:
     """
     type_to_check = type.split("<")[0].strip() if "<" in type else type
     if type_to_check not in type_map:
-        raise Exception(f"Unrecognized type: {type}")
+        return None
     type_val = type_map[type_to_check]
     if not "<" in type:
         return type_val

--- a/cases/comparison/coalesce.yaml
+++ b/cases/comparison/coalesce.yaml
@@ -66,3 +66,48 @@ cases:
     result:
       value: inf
       type: fp64
+  - group: basic
+    args:
+      - value: 7
+        type: decimal<38, 0>
+      - value: 4
+        type: decimal<38, 0>
+    result:
+      value: 7
+      type: decimal<38, 0>
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: 2
+        type: decimal<38, 0>
+    result:
+      value: 2
+      type: decimal<38, 0>
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: decimal<38, 0>
+  - group: basic
+    args:
+      - value: 2000000
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: 2000000
+      type: decimal<38, 0>
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: 2000000
+        type: decimal<38, 0>
+    result:
+      value: 2000000
+      type: decimal<38, 0>

--- a/cases/comparison/equal.yaml
+++ b/cases/comparison/equal.yaml
@@ -59,6 +59,24 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 10
+        type: decimal<38, 0>
+      - value: 10
+        type: decimal<38, 0>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: 10
+        type: decimal<38, 0>
+      - value: 11.25
+        type: decimal<38, 2>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
       - value: inf
         type: fp64
       - value: -inf
@@ -83,6 +101,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: null
+      type: boolean
+  - group: null_input
+    args:
+      - value: 7
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: boolean
+  - group: null_input
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
     result:
       value: null
       type: boolean

--- a/cases/comparison/gt.yaml
+++ b/cases/comparison/gt.yaml
@@ -57,6 +57,24 @@ cases:
     result:
       value: true
       type: boolean
+  - group: basic
+    args:
+      - value: -922337203685775808
+        type: decimal<38, 0>
+      - value: -922337203685775807
+        type: decimal<38, 0>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
+      - value: 7.25
+        type: decimal<38, 2>
+      - value: 2.50
+        type: decimal<38, 2>
+    result:
+      value: true
+      type: boolean
   - group:
       id: null_input
       description: Examples with null as input
@@ -101,6 +119,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: null
+      type: boolean
+  - group: null_input
+    args:
+      - value: 2
+        type: decimal<38, 2>
+      - value: null
+        type: decimal<38, 2>
+    result:
+      value: null
+      type: boolean
+  - group: null_input
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: null
+        type: decimal<38, 2>
     result:
       value: null
       type: boolean

--- a/cases/comparison/gte.yaml
+++ b/cases/comparison/gte.yaml
@@ -68,6 +68,24 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 7.25
+        type: decimal<38, 2>
+      - value: 7.25
+        type: decimal<38, 2>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: 7.25
+        type: decimal<38, 2>
+      - value: 7.27
+        type: decimal<38, 2>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
       - value: inf
         type: fp64
       - value: 1.5e+308
@@ -119,6 +137,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: 7.25
+        type: decimal<38, 2>
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: null
+        type: decimal<38, 2>
     result:
       value: null
       type: boolean

--- a/cases/comparison/is_not_distinct_from.yaml
+++ b/cases/comparison/is_not_distinct_from.yaml
@@ -21,6 +21,24 @@ cases:
     result:
       value: false
       type: boolean
+  - group: basic
+    args:
+      - value: 1.75
+        type: decimal<38, 2>
+      - value: 1.75
+        type: decimal<38, 2>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: 1.75
+        type: decimal<38, 2>
+      - value: 1.1
+        type: decimal<38, 2>
+    result:
+      value: false
+      type: boolean
   - group:
       id: null_input
       description: Examples with null as input
@@ -38,6 +56,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: true
+      type: boolean
+  - group: null_input
+    args:
+      - value: 10
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: false
+      type: boolean
+  - group: null_input
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
     result:
       value: true
       type: boolean

--- a/cases/comparison/is_not_null.yaml
+++ b/cases/comparison/is_not_null.yaml
@@ -26,8 +26,22 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 7.25
+        type: decimal<38, 3>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
       - value: null
         type: i8
     result:
       value: False
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 3>
+    result:
+      value: false
       type: boolean

--- a/cases/comparison/is_null.yaml
+++ b/cases/comparison/is_null.yaml
@@ -19,8 +19,22 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 7.823
+        type: decimal<38, 3>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
       - value: null
         type: i16
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 3>
     result:
       value: true
       type: boolean

--- a/cases/comparison/lt.yaml
+++ b/cases/comparison/lt.yaml
@@ -59,6 +59,24 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 7.25
+        type: decimal<38, 2>
+      - value: 7.25
+        type: decimal<38, 2>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
+      - value: 2.49
+        type: decimal<38, 2>
+      - value: 2.50
+        type: decimal<38, 2>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
       - value: 1.5e+308
         type: fp64
       - value: inf
@@ -101,6 +119,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: 2.50
+        type: decimal<38, 2>
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: null
+        type: decimal<38, 2>
     result:
       value: null
       type: boolean

--- a/cases/comparison/lte.yaml
+++ b/cases/comparison/lte.yaml
@@ -68,6 +68,24 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 7.25
+        type: decimal<38, 2>
+      - value: 7.25
+        type: decimal<38, 2>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: 2.59
+        type: decimal<38, 2>
+      - value: 2.50
+        type: decimal<38, 2>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
       - value: 1.5e+308
         type: fp64
       - value: inf
@@ -119,6 +137,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: 2.50
+        type: decimal<38, 2>
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: null
+        type: decimal<38, 2>
     result:
       value: null
       type: boolean

--- a/cases/comparison/not_equal.yaml
+++ b/cases/comparison/not_equal.yaml
@@ -41,6 +41,24 @@ cases:
       type: boolean
   - group: basic
     args:
+      - value: 9223372036854775807
+        type: decimal<38, 0>
+      - value: 9223372036854775804
+        type: decimal<38, 0>
+    result:
+      value: true
+      type: boolean
+  - group: basic
+    args:
+      - value: 9223372036854775804
+        type: decimal<38, 0>
+      - value: 9223372036854775804
+        type: decimal<38, 0>
+    result:
+      value: false
+      type: boolean
+  - group: basic
+    args:
       - value: inf
         type: fp64
       - value: inf
@@ -83,6 +101,24 @@ cases:
         type: i16
       - value: null
         type: i16
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: 2.50
+        type: decimal<38, 2>
+    result:
+      value: null
+      type: boolean
+  - group: basic
+    args:
+      - value: null
+        type: decimal<38, 2>
+      - value: null
+        type: decimal<38, 2>
     result:
       value: null
       type: boolean

--- a/cases/comparison/nullif.yaml
+++ b/cases/comparison/nullif.yaml
@@ -95,3 +95,21 @@ cases:
     result:
       value: null
       type: boolean
+  - group: null_input
+    args:
+      - value: 10
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: 10
+      type: boolean
+  - group: null_input
+    args:
+      - value: null
+        type: decimal<38, 0>
+      - value: null
+        type: decimal<38, 0>
+    result:
+      value: null
+      type: boolean


### PR DESCRIPTION
* Added test cases for comparison function with decimal arguments
* Fixed a bug (regression in [this](https://github.com/voltrondata/bft/pull/83/files#diff-7a24eb2e7835382b356cfbebd5e3d7ddb0faa463d0716a1d2a83e048244542a8R29) PR) where unsupported dialect type should return error. Dialect checks for "None" if type is unsupported. In previous PR I changed it to throw exception (e.g. [here](https://github.com/voltrondata/bft/blob/0c946db0ff9b53174ed578c9a691792858e92128/bft/testers/snowflake/runner.py#L93-L94) and [here](https://github.com/voltrondata/bft/blob/0c946db0ff9b53174ed578c9a691792858e92128/bft/testers/cudf/runner.py#L95)) hence snowflake tests were failing for unsupported type (i.e. i8)
* Kept precision/scale same as substriat. All input type is "any" so type really doesn't matter. For Result type is either "any" or "boolean" so no specific care needed in type for decimal